### PR TITLE
Generate unique ID for cash accounts and transactions

### DIFF
--- a/src/main/java/org/example/stockmarket/cash/entity/Cash.java
+++ b/src/main/java/org/example/stockmarket/cash/entity/Cash.java
@@ -16,6 +16,7 @@ import java.util.Date;
 public class Cash {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
     @JsonFormat(pattern="yyyy-MM-dd HH:mm:ss", timezone="GMT+8")
     @DateTimeFormat

--- a/src/main/java/org/example/stockmarket/cash/entity/CashModified.java
+++ b/src/main/java/org/example/stockmarket/cash/entity/CashModified.java
@@ -1,9 +1,7 @@
 package org.example.stockmarket.cash.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,6 +20,7 @@ import java.util.Date;
 public class CashModified {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
     private String name;
     @JsonFormat(pattern="yyyy-MM-dd HH:mm:ss", timezone="GMT+8")


### PR DESCRIPTION
Because cashModify ids are not unique, i kept on getting errors when I try to deposit into an existing cash account.
The file changes below fixed the problem on my part. 